### PR TITLE
fix(datastore): allow non-empty values in the slice

### DIFF
--- a/datastore/datastore.go
+++ b/datastore/datastore.go
@@ -682,7 +682,7 @@ func putMutations(keys []*Key, src interface{}) ([]*pb.Mutation, error) {
 	v := reflect.ValueOf(src)
 	var multiArgType multiArgType
 
-	// If kind is of type slice, return error
+	// If kind is not of type slice, return error
 	if kind := v.Kind(); kind != reflect.Slice {
 		return nil, fmt.Errorf("%w: dst: expected slice got %v", ErrInvalidEntityType, kind.String())
 	}

--- a/datastore/save.go
+++ b/datastore/save.go
@@ -288,11 +288,17 @@ func saveSliceProperty(props *[]Property, name string, opts saveOpts, v reflect.
 			return err
 		}
 		for _, p := range elemProps {
-			v, ok := values[p.Name]
-			if !ok {
-				return fmt.Errorf("datastore: unexpected property %q in elem %d of slice", p.Name, i)
+			if len(values) != 0 {
+				v, ok := values[p.Name]
+				if !ok {
+					return fmt.Errorf("datastore: unexpected property %q in elem %d of slice", p.Name, i)
+				}
+				values[p.Name] = append(v, p.Value)
+			} else {
+				// This is the first non-empty element
+				values[p.Name] = []interface{}{p.Value}
+				headProps = elemProps
 			}
-			values[p.Name] = append(v, p.Value)
 		}
 	}
 

--- a/datastore/util_test.go
+++ b/datastore/util_test.go
@@ -690,6 +690,25 @@ var testCases = []testCase{
 		"",
 	},
 	{
+		"omit empty, fields populated, 1st, 2nd and 4th elements in slice are empty",
+		&Omit{
+			A: "a",
+			B: 10,
+			C: true,
+			F: []int{0, 0, 11, 0, 12, 0},
+			S: S{St: "string"},
+		},
+		&PropertyList{
+			Property{Name: "A", Value: "a", NoIndex: false},
+			Property{Name: "Bb", Value: int64(10), NoIndex: false},
+			Property{Name: "C", Value: true, NoIndex: true},
+			Property{Name: "F", Value: []interface{}{int64(11), int64(12)}, NoIndex: false},
+			Property{Name: "St", Value: "string", NoIndex: false},
+		},
+		"",
+		"",
+	},
+	{
 		"omit empty does not propagate",
 		&NoOmits{
 			No: []NoOmit{


### PR DESCRIPTION
Fixes: https://github.com/googleapis/google-cloud-go/issues/6983
**Issue**: https://github.com/googleapis/google-cloud-go/issues/6983

**Cause**: While saving a slice of structs, we try to extract all the fields of struct from first element in array. Then, all the fields in next elements are compared to these fields. For e.g., if array is  [{a: 1, b: 2, c: 3}, {a: 4, b: 5, c: 6}, {a: 1, b: 2, c: 3, d: 10}], the library will throw error that 'd' is unknown field in element 3 since it was not part of the first element.
In issue https://github.com/googleapis/google-cloud-go/issues/6983, when first array element is empty, e.g. [{}, {a: 4, b: 5, c: 6}, {a: 1, b: 2, c: 3, d: 10}] or T{Values: []string{"", "s1", "s2"}}, all the later fields in later elements error out as they were not seen in first element.

**Fix**: Use the first non-empty element of the array as a standard for the fields in rest of the elements
